### PR TITLE
CC-35360: Fix incompatibleImprovements to current 2.3.31 instead of current run…

### DIFF
--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/template/StructTemplate.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/template/StructTemplate.java
@@ -36,7 +36,7 @@ public class StructTemplate {
   final StringTemplateLoader loader;
 
   public StructTemplate() {
-    this.configuration = new Configuration(Configuration.getVersion());
+    this.configuration = new Configuration(Configuration.VERSION_2_3_31);
     this.loader = new StringTemplateLoader();
     this.configuration.setTemplateLoader(this.loader);
     this.configuration.setDefaultEncoding("UTF-8");

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
     <properties>
         <kafka.version>3.9.0</kafka.version>
         <guava.version>31.1-jre</guava.version>
+<!--
+    For upgrading freemarker.version ensure to update
+    om.github.jcustenborder.kafka.connect.utils.template.StructTemplate.configuration
+    version also to updated version
+-->
         <freemarker.version>2.3.31</freemarker.version>
         <jackson.version>2.12.6.20220326</jackson.version>
         <reflections.version>0.9.10</reflections.version>


### PR DESCRIPTION
PR contains the fix for this warning:

Configuration.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.

--------------------------------------------------------------

What is incompatibleImprovements?
This setting controls which enhancements or breaking changes FreeMarker will enable, based on a chosen version number. When set to a specific version, FreeMarker activates all improvements introduced up to (and including) that version.

What is Configuration.getVersion()?
This method dynamically fetches the version of FreeMarker currently in use.

What's wrong with setting incompatibleImprovements = Configuration.getVersion()?
Using the current library version (as provided by getVersion) for incompatibleImprovements means the application's template behavior may unexpectedly change if we upgrade FreeMarker. For example, after an upgrade, templates might behave differently because new "incompatible improvements" are suddenly enabled—even if the templates weren't tested against these changes. This undermines predictable and stable upgrades.

Solution:
Fixed incompatibleImprovements version to 2.3.31 instead of Configuration.getVersion() i.e. current imported library version as it is stable.


