### PR TITLE
Change maven group id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overview
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.jcustenborder.kafka.connect/connect-utils/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.jcustenborder.kafka.connect/connect-utils)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.confluent/connect-utils/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.confluent/connect-utils)
 
 The purpose of this library is to aid with conversions from strings to the proper Kafka Connect data types. Hopefully this library can be usedful in reducing the amount of mind numbing string parsing code.
 

--- a/connect-utils-jackson/pom.xml
+++ b/connect-utils-jackson/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>connect-utils-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>
@@ -71,7 +71,7 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils</artifactId>
         </dependency>
         <dependency>

--- a/connect-utils-parser/pom.xml
+++ b/connect-utils-parser/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>connect-utils-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>
@@ -71,11 +71,11 @@
             <artifactId>connect-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/connect-utils-testing-data/pom.xml
+++ b/connect-utils-testing-data/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>connect-utils-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>
@@ -95,7 +95,7 @@
             <artifactId>connect-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils-jackson</artifactId>
         </dependency>
     </dependencies>

--- a/connect-utils-testing/pom.xml
+++ b/connect-utils-testing/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>connect-utils-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>
@@ -66,11 +66,11 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>connect-utils-jackson</artifactId>
         </dependency>
         <dependency>

--- a/connect-utils/pom.xml
+++ b/connect-utils/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>connect-utils-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.jcustenborder.kafka.connect</groupId>
+    <groupId>io.confluent</groupId>
     <artifactId>connect-utils-parent</artifactId>
     <version>1.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -113,22 +113,22 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.jcustenborder.kafka.connect</groupId>
+                <groupId>io.confluent</groupId>
                 <artifactId>connect-utils</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.jcustenborder.kafka.connect</groupId>
+                <groupId>io.confluent</groupId>
                 <artifactId>connect-utils-testing</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.jcustenborder.kafka.connect</groupId>
+                <groupId>io.confluent</groupId>
                 <artifactId>connect-utils-jackson</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.jcustenborder.kafka.connect</groupId>
+                <groupId>io.confluent</groupId>
                 <artifactId>connect-utils-parser</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Post merging this, tags `1.1.4` and `1.2.1` will be created. So any connectors using the connect-utils artifacts with version `>=` these, will have to change the Maven group id from `com.github.jcustenborder.kafka.connect` to `io.confluent`.

:white_check_mark: Tested with Datagen connector locally.
https://github.com/confluentinc/kafka-connect-datagen/pull/200/changes#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R45
```
<connect.utils.version>1.1.4-SNAPSHOT</connect.utils.version>

<dependency>
            <groupId>io.confluent</groupId>
            <artifactId>connect-utils</artifactId>
            <version>${connect.utils.version}</version>
</dependency>
```